### PR TITLE
表を左寄せにする

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -8,3 +8,4 @@ create-missing = false
 
 [output.html]
 no-section-label = true
+additional-css = ["css/custom.css"]

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,4 @@
+table {
+    margin-left: 0 !important;
+    margin-right: auto !important;
+}


### PR DESCRIPTION
# 概要

表が中央に表示されていたので、みやすさのために左寄せにする

# 変更内容

- custom.cssを追加
- book.tomlにcssを追記

# チェックリスト

- [] 作業中 (ドラフトPR)
---
- [x] サポートしているバージョンを明記した
- [x] ローカルで `mdbook build` を実行して確認した
- [x] modlist.mdを更新した（モジュール追加時）
- [x] SUMMARY.mdを更新した（モジュール追加時）
- [x] [CONTRIBUTING.md](CONTRIBUTING.md) のルールに従っている
- [x] ライセンス／著作権に問題がない

# レビューで見てほしい点

私は見やすくなったと感じたが、他の人からみてどうなのか