### PR TITLE
構造体・トレイトの除外リストが長く見づらかったため、展開可能なdetailsとして表示

### DIFF
--- a/src/start.md
+++ b/src/start.md
@@ -16,6 +16,9 @@ rsdocsjpは、Rust標準ライブラリおよび関連仕様について、公�
 本サイトはよりわかりやすくするために、コードブロックではフルパスを書くようにしています。
 ただし、以下の構造体・トレイトなどは除外されます。
 
+<details>
+<summary>除外される構造体・トレイトの一覧</summary>
+
 - `std::marker::Copy`
 - `std::marker::Copy` (deriveマクロ)
 - `std::marker::Send`
@@ -86,6 +89,8 @@ rsdocsjpは、Rust標準ライブラリおよび関連仕様について、公�
 - `std::concat_bytes` (nightlyのみ)
 - `std::future::Future`
 - `std::future::IntoFuture`
+
+</details>
 
 フルを書かないパスは`std::prelude::rust_2024`に基づいています。
 


### PR DESCRIPTION
# 概要

`src/start.md`の除外リストが非常に長く、見づらかっためデフォルトでは非表示に変更

# 変更内容

同上

# 関連Issue

なし

# チェックリスト

- [] 作業中 (ドラフトPR)
---
- [] サポートしているバージョンを明記した
- [x] ローカルで `mdbook build` を実行して確認した
- [] modlist.mdを更新した（モジュール追加時）
- [] SUMMARY.mdを更新した（モジュール追加時）
- [x] [CONTRIBUTING.md](CONTRIBUTING.md) のルールに従っている
- [x] ライセンス／著作権に問題がない

# レビューで見てほしい点

超絶短い変更ですが、気になったので送ります。